### PR TITLE
Use Span/Memory instead of a raw byte[]

### DIFF
--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -1,4 +1,6 @@
-﻿namespace QoiSharp.Codec;
+﻿using System.Buffers.Binary;
+
+namespace QoiSharp.Codec;
 
 /// <summary>
 /// QOI Codec.
@@ -32,8 +34,7 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static bool IsValidMagic(byte[] magic) => CalculateMagic(magic) == Magic;
+    public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
     
     private static int CalculateMagic(ReadOnlySpan<char> chars) => chars[0] << 24 | chars[1] << 16 | chars[2] << 8 | chars[3];
-    private static int CalculateMagic(ReadOnlySpan<byte> data) => data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
 }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -14,14 +14,14 @@ public static class QoiDecoder
     /// <param name="data">QOI data</param>
     /// <returns>Decoding result.</returns>
     /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
-    public static QoiImage Decode(byte[] data)
+    public static QoiImage Decode(ReadOnlySpan<byte> data)
     {
         if (data.Length < QoiCodec.HeaderSize + QoiCodec.Padding.Length)
         {
             throw new QoiDecodingException("File too short");
         }
         
-        if (!QoiCodec.IsValidMagic(data[..4]))
+        if (!QoiCodec.IsValidMagic(data.Slice (0, 4)))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
         }
@@ -138,6 +138,6 @@ public static class QoiDecoder
             }
         }
 
-        return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);
+        return QoiImage.FromMemory(pixels, width, height, (Channels)channels, colorSpace);
     }
 }

--- a/src/QoiSharp/QoiImage.cs
+++ b/src/QoiSharp/QoiImage.cs
@@ -10,8 +10,12 @@ public class QoiImage
     /// <summary>
     /// Raw pixel data.
     /// </summary>
-    public byte[] Data { get; }
-    
+    public ReadOnlyMemory<byte> Data { get; }
+
+    // Make the zero-copy version available internally for safety. The public API clones the byte[] to guarantee immutability.
+    internal static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+        => new QoiImage(memory, width, height, channels, colorSpace);
+
     /// <summary>
     /// Image width.
     /// </summary>
@@ -31,13 +35,19 @@ public class QoiImage
     /// Color space.
     /// </summary>
     public ColorSpace ColorSpace { get; }
-    
+
     /// <summary>
     /// Default constructor.
     /// </summary>
     public QoiImage(byte[] data, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+        : this(new ReadOnlyMemory<byte>((byte[])data.Clone()), width, height, channels, colorSpace)
     {
-        Data = data;
+
+    }
+
+    QoiImage(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+    {
+        Data = memory;
         Width = width;
         Height = height;
         Channels = channels;

--- a/tests/QoiSharp.Tests/Constants.cs
+++ b/tests/QoiSharp.Tests/Constants.cs
@@ -5,7 +5,7 @@ public static class Constants
     /// <remarks>
     /// Images are taken from here (size ~ 1.1GB): https://qoiformat.org/benchmark/qoi_benchmark_suite.tar
     /// </remarks>
-    public const string RootImagesDirectory = @"E:\Tests\qoi_benchmark_suite\images";
+    public const string RootImagesDirectory = @"C:\qoi_benchmark_suite\images";
 
     public class Images
     {

--- a/tests/QoiSharp.Tests/QoiTests.cs
+++ b/tests/QoiSharp.Tests/QoiTests.cs
@@ -28,7 +28,7 @@ public class QoiTests
         
         // Assert
         var img = QoiDecoder.Decode(qoiData);
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -52,7 +52,7 @@ public class QoiTests
         
         // Assert
         var img = QoiDecoder.Decode(qoiData);
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -76,7 +76,7 @@ public class QoiTests
         var img = QoiDecoder.Decode(qoiData);
 
         // Assert
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -100,7 +100,7 @@ public class QoiTests
         var img = QoiDecoder.Decode(qoiData);
 
         // Assert
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);


### PR DESCRIPTION
This is a little more flexible as you can slice
the Span and easily decode multiple images from
the same underlying byte[]. By using a byte[]
parameter you force users to ensure the image
they want to decode is available at offset '0'
in the array.

Additionally, by exposing QoiImage using
ReadOnlyMemory<byte> it becomes immutable. The
only gotcha is that implicit casting to
ReadOnlyMemory<byte> can introduce subtle
bugs where the user creates a QoiImage from
a byte[], then reuses the byte[] for something
else, which then corrupts the QoiImage.