### PR TITLE
Perf optimisations

### DIFF
--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -34,5 +34,8 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
+    public static int CalculateHashTableIndexAsInt(int r, int g, int b, int a) =>
+        ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize;
+
     public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -34,8 +34,5 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static int CalculateHashTableIndex(Span<byte> rgba) =>
-        (rgba[0] * 3 + rgba[1] * 5 + rgba[2] * 7 + rgba[3] * 11) % HashTableSize * 4;
-
     public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -1,4 +1,6 @@
-﻿namespace QoiSharp.Codec;
+﻿using System.Buffers.Binary;
+
+namespace QoiSharp.Codec;
 
 /// <summary>
 /// QOI Codec.
@@ -32,8 +34,7 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static bool IsValidMagic(byte[] magic) => CalculateMagic(magic) == Magic;
+    public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
     
     private static int CalculateMagic(ReadOnlySpan<char> chars) => chars[0] << 24 | chars[1] << 16 | chars[2] << 8 | chars[3];
-    private static int CalculateMagic(ReadOnlySpan<byte> data) => data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -34,8 +34,8 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static int CalculateHashTableIndexAsInt(int r, int g, int b, int a) =>
-        ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize;
+    public static int CalculateHashTableIndex(Span<byte> rgba) =>
+        (rgba[0] * 3 + rgba[1] * 5 + rgba[2] * 7 + rgba[3] * 11) % HashTableSize * 4;
 
     public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -27,14 +27,12 @@ public static class QoiCodec
     
     public const byte HeaderSize = 14;
     public const string MagicString = "qoif";
-    
-    public static readonly int Magic = CalculateMagic(MagicString.AsSpan());
-    public static readonly byte[] Padding = {0, 0, 0, 0, 0, 0, 0, 1};
+
+    public const int Magic = 'q' << 24 | 'o' << 16 | 'i' << 8 | 'f';
+    public static readonly ReadOnlyMemory<byte> Padding = new byte[] {0, 0, 0, 0, 0, 0, 0, 1};
 
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
     public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
-    
-    private static int CalculateMagic(ReadOnlySpan<char> chars) => chars[0] << 24 | chars[1] << 16 | chars[2] << 8 | chars[3];
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -34,5 +34,5 @@ public static class QoiCodec
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
+    public static bool IsValidMagic(ReadOnlySpan<byte> magic) => BinaryPrimitives.ReadInt32BigEndian(magic) == Magic;
 }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -129,14 +129,8 @@ public static class QoiDecoder
             }
         }
         
-        int pixelsEnd = data.Length - QoiCodec.Padding.Length;
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++) 
-        {
-            if (data[pixelsEnd + padIdx] != QoiCodec.Padding[padIdx]) 
-            {
-                throw new InvalidOperationException("Invalid padding");
-            }
-        }
+        if (!QoiCodec.Padding.Span.SequenceEqual(data.Slice(data.Length - QoiCodec.Padding.Length)))
+            throw new InvalidOperationException("Invalid padding");
 
         return QoiImage.FromMemory(pixels, width, height, (Channels)channels, colorSpace);
     }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -21,7 +21,7 @@ public static class QoiDecoder
             throw new QoiDecodingException("File too short");
         }
         
-        if (!QoiCodec.IsValidMagic(data.Slice (0, 4)))
+        if (!QoiCodec.IsValidMagic(data.Slice(0, 4)))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
         }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -14,14 +14,14 @@ public static class QoiDecoder
     /// <param name="data">QOI data</param>
     /// <returns>Decoding result.</returns>
     /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
-    public static QoiImage Decode(byte[] data)
+    public static QoiImage Decode(ReadOnlySpan<byte> data)
     {
         if (data.Length < QoiCodec.HeaderSize + QoiCodec.Padding.Length)
         {
             throw new QoiDecodingException("File too short");
         }
         
-        if (!QoiCodec.IsValidMagic(data[..4]))
+        if (!QoiCodec.IsValidMagic(data.Slice (0, 4)))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
         }
@@ -138,6 +138,6 @@ public static class QoiDecoder
             }
         }
 
-        return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);
+        return QoiImage.FromMemory(pixels, width, height, (Channels)channels, colorSpace);
     }
 }

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -53,22 +53,16 @@ public static class QoiEncoder
 
         Span<int> index = stackalloc int[QoiCodec.HashTableSize];
 
-        Span<byte> prev = stackalloc byte[4];
-        prev.Clear();
-        prev[3] = 255;
-
-        Span<byte> rgba = stackalloc byte[4];
-        prev.CopyTo(rgba);
-
+        Span<byte> prev = stackalloc byte[4] { 0, 0, 0, 255 };
+        Span<byte> rgba = stackalloc byte[4] { 0, 0, 0, 255 };
         Span<byte> rgb = rgba.Slice(0, 3);
 
         Span<int> prevAsInt = MemoryMarshal.Cast<byte, int>(prev);
         Span<int> rgbaAsInt = MemoryMarshal.Cast<byte, int>(rgba);
 
         int run = 0;
-        int p = QoiCodec.HeaderSize;
-
         int counter = 0;
+        int p = QoiCodec.HeaderSize;
         pixels = pixels.Slice(0, width * height * channels);
         while (pixels.Length > 0)
         {

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -62,6 +62,7 @@ public static class QoiEncoder
 
         Span<int> prevAsInt = MemoryMarshal.Cast<byte, int>(prev);
         Span<int> rgbaAsInt = MemoryMarshal.Cast<byte, int>(rgba);
+        Span<int> indexAsInt = MemoryMarshal.Cast<byte, int>(index);
 
         int run = 0;
         int p = QoiCodec.HeaderSize;
@@ -92,15 +93,15 @@ public static class QoiEncoder
                     run = 0;
                 }
 
-                int indexPos = QoiCodec.CalculateHashTableIndex(rgba);
+                int indexPos = QoiCodec.CalculateHashTableIndex(rgba)/4;
 
-                if (RgbaEquals(rgba[0], rgba[1], rgba[2], rgba[3], index[indexPos], index[indexPos + 1], index[indexPos + 2], index[indexPos + 3]))
+                if (rgbaAsInt[0] == indexAsInt[indexPos])
                 {
-                    buffer[p++] = (byte)(QoiCodec.Index | (indexPos / 4));
+                    buffer[p++] = (byte)(QoiCodec.Index | (indexPos));
                 }
                 else
                 {
-                    rgba.CopyTo(index.Slice(indexPos));
+                    indexAsInt[indexPos] = rgbaAsInt[0];
 
                     if (rgba[3] == prev[3])
                     {

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -51,7 +51,7 @@ public static class QoiEncoder
         buffer[12] = (byte)channels;
         buffer[13] = colorSpace;
 
-        byte[] index = new byte[QoiCodec.HashTableSize * 4];
+        Span<byte> index = stackalloc byte[QoiCodec.HashTableSize * 4];
 
         Span<byte> prev = stackalloc byte[4];
         prev.Clear();
@@ -100,7 +100,7 @@ public static class QoiEncoder
                 }
                 else
                 {
-                    rgba.CopyTo(index.AsSpan(indexPos));
+                    rgba.CopyTo(index.Slice(indexPos));
 
                     if (rgba[3] == prev[3])
                     {

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -69,7 +69,7 @@ public static class QoiEncoder
             pixels.Slice(0, channels).CopyTo(rgba);
             pixels = pixels.Slice(channels);
 
-            if (prevAsInt[0] == rgbaAsInt [0])
+            if (prevAsInt[0] == rgbaAsInt[0])
             {
                 run++;
                 if (run == 62 || pixels.Length == 0)
@@ -113,8 +113,7 @@ public static class QoiEncoder
                         }
                         else if (vgr is > -9 and < 8 &&
                                  vg is > -33 and < 32 &&
-                                 vgb is > -9 and < 8
-                                )
+                                 vgb is > -9 and < 8)
                         {
                             buffer[p++] = (byte)(QoiCodec.Luma | (vg + 32));
                             buffer[p++] = (byte)((vgr + 8) << 4 | (vgb + 8));
@@ -129,7 +128,7 @@ public static class QoiEncoder
                     else
                     {
                         buffer[p++] = QoiCodec.Rgba;
-                        rgba.CopyTo(buffer.Slice (p));
+                        rgba.CopyTo(buffer.Slice(p));
                         p += 4;
                     }
                 }
@@ -137,7 +136,7 @@ public static class QoiEncoder
             prevAsInt[0] = rgbaAsInt[0];
         }
 
-        QoiCodec.Padding.Span.CopyTo(buffer.Slice (p));
+        QoiCodec.Padding.Span.CopyTo(buffer.Slice(p));
         p += QoiCodec.Padding.Length;
 
         return p;

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -1,6 +1,8 @@
 ﻿using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
+using System.Buffers.Binary;
+
 namespace QoiSharp;
 
 /// <summary>
@@ -41,20 +43,9 @@ public static class QoiEncoder
         if (buffer.Length < QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * channels))
             return -1;
 
-        buffer[0] = (byte)(QoiCodec.Magic >> 24);
-        buffer[1] = (byte)(QoiCodec.Magic >> 16);
-        buffer[2] = (byte)(QoiCodec.Magic >> 8);
-        buffer[3] = (byte)QoiCodec.Magic;
-
-        buffer[4] = (byte)(width >> 24);
-        buffer[5] = (byte)(width >> 16);
-        buffer[6] = (byte)(width >> 8);
-        buffer[7] = (byte)width;
-
-        buffer[8] = (byte)(height >> 24);
-        buffer[9] = (byte)(height >> 16);
-        buffer[10] = (byte)(height >> 8);
-        buffer[11] = (byte)height;
+        BinaryPrimitives.WriteInt32BigEndian(buffer, QoiCodec.Magic);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(4), width);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(8), height);
 
         buffer[12] = channels;
         buffer[13] = colorSpace;
@@ -168,11 +159,7 @@ public static class QoiEncoder
             prevA = a;
         }
 
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++)
-        {
-            buffer[p + padIdx] = QoiCodec.Padding[padIdx];
-        }
-
+        QoiCodec.Padding.Span.CopyTo(buffer.Slice (p));
         p += QoiCodec.Padding.Length;
 
         return p;

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -60,6 +60,8 @@ public static class QoiEncoder
         Span<byte> rgba = stackalloc byte[4];
         prev.CopyTo(rgba);
 
+        Span<byte> rgb = rgba.Slice(0, 3);
+
         Span<int> prevAsInt = MemoryMarshal.Cast<byte, int>(prev);
         Span<int> rgbaAsInt = MemoryMarshal.Cast<byte, int>(rgba);
 
@@ -126,7 +128,7 @@ public static class QoiEncoder
                         else
                         {
                             buffer[p++] = QoiCodec.Rgb;
-                            rgba.Slice(0, 3).CopyTo(buffer.Slice(p));
+                            rgb.CopyTo(buffer.Slice(p));
                             p += 3;
                         }
                     }

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -92,7 +92,7 @@ public static class QoiEncoder
                     run = 0;
                 }
 
-                int indexPos = QoiCodec.CalculateHashTableIndex(rgba[0], rgba[1], rgba[2], rgba[3]);
+                int indexPos = QoiCodec.CalculateHashTableIndex(rgba);
 
                 if (RgbaEquals(rgba[0], rgba[1], rgba[2], rgba[3], index[indexPos], index[indexPos + 1], index[indexPos + 2], index[indexPos + 3]))
                 {

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -66,10 +66,8 @@ public static class QoiEncoder
         int run = 0;
         int p = QoiCodec.HeaderSize;
 
-        int pixelsLength = width * height * channels;
-        int pixelsEnd = pixelsLength - channels;
         int counter = 0;
-
+        pixels = pixels.Slice(0, width * height * channels);
         while (pixels.Length > 0)
         {
             pixels.Slice(0, channels).CopyTo(rgba);

--- a/src/QoiSharp/QoiImage.cs
+++ b/src/QoiSharp/QoiImage.cs
@@ -13,8 +13,8 @@ public class QoiImage
     public ReadOnlyMemory<byte> Data { get; }
 
     // Make the zero-copy version available internally for safety. The public API clones the byte[] to guarantee immutability.
-    public static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
-        => new QoiImage(memory, width, height, channels, colorSpace);
+    public static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb) 
+        => new(memory, width, height, channels, colorSpace);
 
     /// <summary>
     /// Image width.
@@ -45,7 +45,7 @@ public class QoiImage
 
     }
 
-    QoiImage(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+    private QoiImage(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
     {
         Data = memory;
         Width = width;

--- a/src/QoiSharp/QoiImage.cs
+++ b/src/QoiSharp/QoiImage.cs
@@ -13,7 +13,7 @@ public class QoiImage
     public ReadOnlyMemory<byte> Data { get; }
 
     // Make the zero-copy version available internally for safety. The public API clones the byte[] to guarantee immutability.
-    internal static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+    public static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
         => new QoiImage(memory, width, height, channels, colorSpace);
 
     /// <summary>

--- a/src/QoiSharp/QoiImage.cs
+++ b/src/QoiSharp/QoiImage.cs
@@ -10,8 +10,12 @@ public class QoiImage
     /// <summary>
     /// Raw pixel data.
     /// </summary>
-    public byte[] Data { get; }
-    
+    public ReadOnlyMemory<byte> Data { get; }
+
+    // Make the zero-copy version available internally for safety. The public API clones the byte[] to guarantee immutability.
+    internal static QoiImage FromMemory(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+        => new QoiImage(memory, width, height, channels, colorSpace);
+
     /// <summary>
     /// Image width.
     /// </summary>
@@ -31,13 +35,19 @@ public class QoiImage
     /// Color space.
     /// </summary>
     public ColorSpace ColorSpace { get; }
-    
+
     /// <summary>
     /// Default constructor.
     /// </summary>
     public QoiImage(byte[] data, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+        : this(new ReadOnlyMemory<byte>((byte[])data.Clone()), width, height, channels, colorSpace)
     {
-        Data = data;
+
+    }
+
+    QoiImage(ReadOnlyMemory<byte> memory, int width, int height, Channels channels, ColorSpace colorSpace = ColorSpace.SRgb)
+    {
+        Data = memory;
         Width = width;
         Height = height;
         Channels = channels;

--- a/tests/QoiSharp.Cli/Benchmarking/DecodingBenchmark.cs
+++ b/tests/QoiSharp.Cli/Benchmarking/DecodingBenchmark.cs
@@ -8,20 +8,4 @@ namespace QoiSharp.Cli.Benchmarking;
 [Config(typeof(ShortRunConfig))]
 public class DecodingBenchmark
 {
-    [GlobalSetup]
-    public async Task GlobalSetup()
-    {
-    }
-
-    [Benchmark(Description = "PNG Decoding")]
-    public void PngDecoding()
-    {
-        // byte[] data = ImageResult.FromMemory(_pngData, ColorComponents.RedGreenBlueAlpha).Data;
-    }
-
-    [Benchmark(Description = "QOI Decoding")]
-    public void QoiDecoding()
-    {
-        // byte[] data = QoiDecoder.Decode(_qoiData).Data;
-    }
 }

--- a/tests/QoiSharp.Cli/Benchmarking/EncodingBenchmark.cs
+++ b/tests/QoiSharp.Cli/Benchmarking/EncodingBenchmark.cs
@@ -1,10 +1,29 @@
 ﻿using BenchmarkDotNet.Attributes;
 using QoiSharp.Cli.Benchmarking.Configs;
 
+using StbImageSharp;
+
 namespace QoiSharp.Cli.Benchmarking;
 
-[Config(typeof(ShortRunConfig))]
+[MemoryDiagnoser]
 public class EncodingBenchmark
 {
-   
+    readonly ImageResult image;
+    readonly byte[] rawData;
+    readonly byte[] encoded;
+
+    public EncodingBenchmark()
+    {
+        rawData = File.ReadAllBytes(@"C:\qoi_benchmark_suite\images\photo_kodak\kodim01.png");
+        image = ImageResult.FromMemory(rawData, ColorComponents.RedGreenBlueAlpha);
+        encoded = new byte[image.Data.Length];
+     }
+
+
+    [Benchmark(Description = "QOI Decoding")]
+    public void QoiEncoding()
+    {
+        var qoi = QoiImage.FromMemory (image.Data, image.Width, image.Height, image.SourceComp == ColorComponents.RedGreenBlueAlpha ? Codec.Channels.RgbWithAlpha : Codec.Channels.Rgb);
+        QoiEncoder.Encode(qoi, encoded);
+    }
 }

--- a/tests/QoiSharp.Cli/Program.cs
+++ b/tests/QoiSharp.Cli/Program.cs
@@ -1,3 +1,5 @@
+using BenchmarkDotNet.Running;
+
 using Microsoft.Extensions.DependencyInjection;
 using QoiSharp.Cli.Commands;
 using QoiSharp.Cli.Commands.Benchmarks;
@@ -10,17 +12,9 @@ namespace QoiSharp.Cli
     {
         public static int Main(string[] args)
         {
-            var registrations = new ServiceCollection();
-            var registrar = new TypeRegistrar(registrations);
-            
-            var app = new CommandApp(registrar);
-            app.Configure(config =>
-            {
-                config.AddCommand<DecodingBenchmarkCommand>("benchmark-decoding");
-                config.AddCommand<EncodeImageToQoiCommand>("encode-to-qoi");
-            });
-            
-            return app.Run(args);
+            new QoiSharp.Cli.Benchmarking.EncodingBenchmark().QoiEncoding();
+            var summary = BenchmarkRunner.Run(typeof(QoiSharp.Cli.Benchmarking.EncodingBenchmark));
+            return 1;
         }
     }
 }

--- a/tests/QoiSharp.Tests/Constants.cs
+++ b/tests/QoiSharp.Tests/Constants.cs
@@ -5,7 +5,7 @@ public static class Constants
     /// <remarks>
     /// Images are taken from here (size ~ 1.1GB): https://qoiformat.org/benchmark/qoi_benchmark_suite.tar
     /// </remarks>
-    public const string RootImagesDirectory = @"E:\Tests\qoi_benchmark_suite\images";
+    public const string RootImagesDirectory = @"C:\qoi_benchmark_suite\images";
 
     public class Images
     {

--- a/tests/QoiSharp.Tests/QoiTests.cs
+++ b/tests/QoiSharp.Tests/QoiTests.cs
@@ -28,7 +28,7 @@ public class QoiTests
         
         // Assert
         var img = QoiDecoder.Decode(qoiData);
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -52,7 +52,7 @@ public class QoiTests
         
         // Assert
         var img = QoiDecoder.Decode(qoiData);
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -76,7 +76,7 @@ public class QoiTests
         var img = QoiDecoder.Decode(qoiData);
 
         // Assert
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);
@@ -100,7 +100,7 @@ public class QoiTests
         var img = QoiDecoder.Decode(qoiData);
 
         // Assert
-        Assert.True(img.Data.SequenceEqual(qoiImage.Data));
+        Assert.True(img.Data.Span.SequenceEqual(qoiImage.Data.Span));
         img.Width.Should().Be(qoiImage.Width);
         img.Height.Should().Be(qoiImage.Height);
         img.Channels.Should().Be(qoiImage.Channels);


### PR DESCRIPTION
This builds on top of the previous PRs to leverage the benefits of Span<T> in the encoding process.

Before these changes:
```
// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1415 (21H2)
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT


|         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|----------:|
| 'QOI Encoding' | 5.057 ms | 0.0997 ms | 0.2292 ms | 234.3750 | 234.3750 | 234.3750 |      1 MB |
```

NOTE: I did tweak the `Encode` method to take a pre-allocated buffer, just like the optimised method does. This means the destination byte[] is allocated *once* and both optimised/unoptimised methods encode to the same buffer repeatedly. The memory stats would be significantly worse otherwise. 

With the optimisations:
```
// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1415 (21H2)
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT


|         Method |     Mean |     Error |    StdDev | Allocated |
|--------------- |---------:|----------:|----------:|----------:|
| 'QOI Encoding' | 4.290 ms | 0.0133 ms | 0.0125 ms |      52 B |
```

Encoding is a zero-allocation operation now (as long as you use a pre-allocated buffer). It's also a fair bit faster.