### PR TITLE
30% performance increase

### DIFF
--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -29,11 +29,14 @@ public static class QoiCodec
     public static readonly int Magic = CalculateMagic(MagicString.AsSpan());
     public static readonly byte[] Padding = {0, 0, 0, 0, 0, 0, 0, 1};
 
+    public static int CalculateHashTableIndex(int r, int g, int b) =>
+        ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 * 11) % HashTableSize * 4;
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
     public static bool IsValidMagic(byte[] magic) => CalculateMagic(magic) == Magic;
-    
+    public static bool IsValidMagic(ReadOnlySpan<byte> magic) => CalculateMagic(magic) == Magic;
+
     private static int CalculateMagic(ReadOnlySpan<char> chars) => chars[0] << 24 | chars[1] << 16 | chars[2] << 8 | chars[3];
     private static int CalculateMagic(ReadOnlySpan<byte> data) => data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
 }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -1,4 +1,6 @@
-﻿using QoiSharp.Codec;
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
 namespace QoiSharp;
@@ -6,7 +8,7 @@ namespace QoiSharp;
 /// <summary>
 /// QOI decoder.
 /// </summary>
-public static class QoiDecoder 
+public static class QoiDecoder
 {
     /// <summary>
     /// Decodes QOI data into raw pixel data.
@@ -14,13 +16,13 @@ public static class QoiDecoder
     /// <param name="data">QOI data</param>
     /// <returns>Decoding result.</returns>
     /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
-    public static QoiImage Decode(byte[] data)
+    public static QoiImage Decode(ReadOnlySpan<byte> data)
     {
         if (data.Length < QoiCodec.HeaderSize + QoiCodec.Padding.Length)
         {
             throw new QoiDecodingException("File too short");
         }
-        
+
         if (!QoiCodec.IsValidMagic(data[..4]))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
@@ -28,8 +30,8 @@ public static class QoiDecoder
 
         int width = data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7];
         int height = data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11];
-        byte channels = data[12]; 
-        var colorSpace = (ColorSpace)data[13];
+        byte channels = data[12];
+        ColorSpace colorSpace = (ColorSpace)data[13];
 
         if (width == 0)
         {
@@ -39,31 +41,123 @@ public static class QoiDecoder
         {
             throw new QoiDecodingException($"Invalid height: {height}. Maximum for this image is {QoiCodec.MaxPixels / width - 1}");
         }
-        if (channels is not 3 and not 4)
+
+        byte[] pixels = new byte[width * height * channels];
+
+        if (channels == 3) Decode3Channel(data.Slice(QoiCodec.HeaderSize), pixels);
+        else if (channels == 4) Decode4Channel(data.Slice(QoiCodec.HeaderSize), pixels);
+        else throw new QoiDecodingException($"Invalid number of channels: {channels}");
+
+        int pixelsEnd = data.Length - QoiCodec.Padding.Length;
+        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++)
         {
-            throw new QoiDecodingException($"Invalid number of channels: {channels}");
-        }
-        
-        byte[] index = new byte[QoiCodec.HashTableSize * 4];
-        if (channels == 3) // TODO: delete
-        {
-            for (int indexPos = 3; indexPos < index.Length; indexPos += 4)
+            if (data[pixelsEnd + padIdx] != QoiCodec.Padding[padIdx])
             {
-                index[indexPos] = 255;
+                throw new InvalidOperationException("Invalid padding");
             }
         }
 
-        byte[] pixels = new byte[width * height * channels];
-        
+        return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);
+    }
+
+    /// <summary>
+    /// Decode QOI image data of an RGB image
+    /// </summary>
+    /// <param name="data">encoded data</param>
+    /// <param name="pixels">destination of decoded image data</param>
+    /// <returns>used byte count inside <paramref name="pixels"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Decode3Channel(ReadOnlySpan<byte> data, Span<byte> pixels)
+    {
+        byte[] index = ArrayPool<byte>.Shared.Rent(QoiCodec.HashTableSize * 4);
+        for (int indexPos = 3; indexPos < index.Length; indexPos += 4)
+        {
+            index[indexPos] = 255;
+        }
+
+        byte r = 0;
+        byte g = 0;
+        byte b = 0;
+
+        int run = 0;
+        int p = 0;
+
+        for (int pxPos = 0; pxPos < pixels.Length; pxPos += 3)
+        {
+            if (run > 0)
+            {
+                run--;
+            }
+            else
+            {
+                byte b1 = data[p++];
+
+                if (b1 == QoiCodec.Rgb)
+                {
+                    r = data[p++];
+                    g = data[p++];
+                    b = data[p++];
+                }
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Index)
+                {
+                    int indexPos = (b1 & ~QoiCodec.Mask2) * 4;
+                    r = index[indexPos];
+                    g = index[indexPos + 1];
+                    b = index[indexPos + 2];
+                }
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Diff)
+                {
+                    r += (byte)(((b1 >> 4) & 0x03) - 2);
+                    g += (byte)(((b1 >> 2) & 0x03) - 2);
+                    b += (byte)((b1 & 0x03) - 2);
+                }
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Luma)
+                {
+                    int b2 = data[p++];
+                    int vg = (b1 & 0x3F) - 32;
+                    r += (byte)(vg - 8 + ((b2 >> 4) & 0x0F));
+                    g += (byte)vg;
+                    b += (byte)(vg - 8 + (b2 & 0x0F));
+                }
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Run)
+                {
+                    run = b1 & 0x3F;
+                }
+
+                int indexPos2 = QoiCodec.CalculateHashTableIndex(r, g, b);
+                index[indexPos2] = r;
+                index[indexPos2 + 1] = g;
+                index[indexPos2 + 2] = b;
+            }
+
+            pixels[pxPos] = r;
+            pixels[pxPos + 1] = g;
+            pixels[pxPos + 2] = b;
+        }
+
+        ArrayPool<byte>.Shared.Return(index);
+    }
+
+    /// <summary>
+    /// Decode QOI image data of an RGB image
+    /// </summary>
+    /// <param name="data">encoded data</param>
+    /// <param name="pixels">destination of decoded image data</param>
+    /// <returns>used byte count inside <paramref name="pixels"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Decode4Channel(ReadOnlySpan<byte> data, Span<byte> pixels)
+    {
+        byte[] index = ArrayPool<byte>.Shared.Rent(QoiCodec.HashTableSize * 4);
+
         byte r = 0;
         byte g = 0;
         byte b = 0;
         byte a = 255;
-        
-        int run = 0;
-        int p = QoiCodec.HeaderSize;
 
-        for (int pxPos = 0; pxPos < pixels.Length; pxPos += channels)
+        int run = 0;
+        int p = 0;
+
+        for (int pxPos = 0; pxPos < pixels.Length; pxPos += 4)
         {
             if (run > 0)
             {
@@ -100,7 +194,7 @@ public static class QoiDecoder
                     g += (byte)(((b1 >> 2) & 0x03) - 2);
                     b += (byte)((b1 & 0x03) - 2);
                 }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Luma) 
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Luma)
                 {
                     int b2 = data[p++];
                     int vg = (b1 & 0x3F) - 32;
@@ -108,11 +202,11 @@ public static class QoiDecoder
                     g += (byte)vg;
                     b += (byte)(vg - 8 + (b2 & 0x0F));
                 }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Run) 
+                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Run)
                 {
                     run = b1 & 0x3F;
                 }
-                
+
                 int indexPos2 = QoiCodec.CalculateHashTableIndex(r, g, b, a);
                 index[indexPos2] = r;
                 index[indexPos2 + 1] = g;
@@ -123,21 +217,9 @@ public static class QoiDecoder
             pixels[pxPos] = r;
             pixels[pxPos + 1] = g;
             pixels[pxPos + 2] = b;
-            if (channels == 4)
-            {
-                pixels[pxPos + 3] = a;
-            }
-        }
-        
-        int pixelsEnd = data.Length - QoiCodec.Padding.Length;
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++) 
-        {
-            if (data[pixelsEnd + padIdx] != QoiCodec.Padding[padIdx]) 
-            {
-                throw new InvalidOperationException("Invalid padding");
-            }
+            pixels[pxPos + 3] = a;
         }
 
-        return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);
+        ArrayPool<byte>.Shared.Return(index);
     }
 }

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -1,4 +1,6 @@
-﻿using QoiSharp.Codec;
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
 namespace QoiSharp;
@@ -30,9 +32,9 @@ public static class QoiEncoder
         int height = image.Height;
         byte channels = (byte)image.Channels;
         byte colorSpace = (byte)image.ColorSpace;
-        byte[] pixels = image.Data;
+        ReadOnlySpan<byte> pixels = image.Data;
 
-        byte[] bytes = new byte[QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * channels)];
+        byte[] bytes = ArrayPool<byte>.Shared.Rent(QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * channels));
 
         bytes[0] = (byte)(QoiCodec.Magic >> 24);
         bytes[1] = (byte)(QoiCodec.Magic >> 16);
@@ -52,35 +54,129 @@ public static class QoiEncoder
         bytes[12] = channels;
         bytes[13] = colorSpace;
 
-        byte[] index = new byte[QoiCodec.HashTableSize * 4];
+        int p;
+        if (channels == 3) p = Encode3Channel(bytes, pixels, width * height);
+        else if (channels == 4) p = Encode4Channel(bytes, pixels, width * height);
+        else throw new InvalidDataException("Unexpected amount of channels to encode");
+
+        Array.Copy(QoiCodec.Padding, 0, bytes, p, QoiCodec.Padding.Length);
+        p += QoiCodec.Padding.Length;
+
+        byte[] encodedData = bytes[..p];
+        ArrayPool<byte>.Shared.Return(bytes);
+        return encodedData;
+    }
+
+    /// <summary>
+    /// Encode the image data of an RGB image
+    /// </summary>
+    /// <param name="bytes">output location of the encoded bytes</param>
+    /// <param name="pixels">image data to encode</param>
+    /// <param name="totalPixels">total amount of pixels in the image</param>
+    /// <returns>used byte count inside <paramref name="bytes"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Encode3Channel(Span<byte> bytes, ReadOnlySpan<byte> pixels, int totalPixels)
+    {
+        byte[] indexArray = ArrayPool<byte>.Shared.Rent(QoiCodec.HashTableSize * 4);
+        Span<byte> index = new Span<byte>(indexArray);
+
+        byte prevR = 0;
+        byte prevG = 0;
+        byte prevB = 0;
+
+        byte r;
+        byte g;
+        byte b;
+
+        int run = 0;
+        int p = QoiCodec.HeaderSize;
+
+        int pixelsLength = totalPixels * 3;
+        int pixelsEnd = pixelsLength - 3;
+
+        for (int pxPos = 0; pxPos < pixelsLength; pxPos += 3)
+        {
+            r = pixels[pxPos];
+            g = pixels[pxPos + 1];
+            b = pixels[pxPos + 2];
+
+            if (RgbEquals(prevR, prevG, prevB, r, g, b))
+            {
+                run++;
+                if (run == 62 || pxPos == pixelsEnd)
+                {
+                    bytes[p++] = (byte)(QoiCodec.Run | (run - 1));
+                    run = 0;
+                }
+            }
+            else
+            {
+                if (run > 0)
+                {
+                    bytes[p++] = (byte)(QoiCodec.Run | (run - 1));
+                    run = 0;
+                }
+
+                int indexPos = QoiCodec.CalculateHashTableIndex(r, g, b);
+
+                if (RgbEquals(r, g, b, index[indexPos], index[indexPos + 1], index[indexPos + 2]))
+                {
+                    bytes[p++] = (byte)(QoiCodec.Index | (indexPos / 4));
+                }
+                else
+                {
+                    index[indexPos] = r;
+                    index[indexPos + 1] = g;
+                    index[indexPos + 2] = b;
+
+                    CompressRGB(bytes, r, prevR, g, prevG, b, prevB, ref p);
+                }
+            }
+
+            prevR = r;
+            prevG = g;
+            prevB = b;
+        }
+
+        return p;
+    }
+
+
+    /// <summary>
+    /// Encode the image data of an RGBA image
+    /// </summary>
+    /// <param name="bytes">output location of the encoded bytes</param>
+    /// <param name="pixels">image data to encode</param>
+    /// <param name="totalPixels">total amount of pixels in the image</param>
+    /// <returns>used byte count inside <paramref name="bytes"/></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Encode4Channel(Span<byte> bytes, ReadOnlySpan<byte> pixels, int totalPixels)
+    {
+        byte[] indexArray = ArrayPool<byte>.Shared.Rent(QoiCodec.HashTableSize * 4);
+        Span<byte> index = new Span<byte>(indexArray);
 
         byte prevR = 0;
         byte prevG = 0;
         byte prevB = 0;
         byte prevA = 255;
 
-        byte r = 0;
-        byte g = 0;
-        byte b = 0;
-        byte a = 255;
+        byte r;
+        byte g;
+        byte b;
+        byte a;
 
         int run = 0;
         int p = QoiCodec.HeaderSize;
-        bool hasAlpha = channels == 4;
 
-        int pixelsLength = width * height * channels;
-        int pixelsEnd = pixelsLength - channels;
-        int counter = 0;
+        int pixelsLength = totalPixels * 4;
+        int pixelsEnd = pixelsLength - 4;
 
-        for (int pxPos = 0; pxPos < pixelsLength; pxPos += channels)
+        for (int pxPos = 0; pxPos < pixelsLength; pxPos += 4)
         {
             r = pixels[pxPos];
             g = pixels[pxPos + 1];
             b = pixels[pxPos + 2];
-            if (hasAlpha)
-            {
-                a = pixels[pxPos + 3];
-            }
+            a = pixels[pxPos + 3];
 
             if (RgbaEquals(prevR, prevG, prevB, prevA, r, g, b, a))
             {
@@ -114,35 +210,7 @@ public static class QoiEncoder
 
                     if (a == prevA)
                     {
-                        int vr = r - prevR;
-                        int vg = g - prevG;
-                        int vb = b - prevB;
-
-                        int vgr = vr - vg;
-                        int vgb = vb - vg;
-
-                        if (vr is > -3 and < 2 &&
-                            vg is > -3 and < 2 &&
-                            vb is > -3 and < 2)
-                        {
-                            counter++;
-                            bytes[p++] = (byte)(QoiCodec.Diff | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2));
-                        }
-                        else if (vgr is > -9 and < 8 &&
-                                 vg is > -33 and < 32 &&
-                                 vgb is > -9 and < 8
-                                )
-                        {
-                            bytes[p++] = (byte)(QoiCodec.Luma | (vg + 32));
-                            bytes[p++] = (byte)((vgr + 8) << 4 | (vgb + 8));
-                        }
-                        else
-                        {
-                            bytes[p++] = QoiCodec.Rgb;
-                            bytes[p++] = r;
-                            bytes[p++] = g;
-                            bytes[p++] = b;
-                        }
+                        CompressRGB(bytes, r, prevR, g, prevG, b, prevB, ref p);
                     }
                     else
                     {
@@ -161,19 +229,65 @@ public static class QoiEncoder
             prevA = a;
         }
 
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++)
-        {
-            bytes[p + padIdx] = QoiCodec.Padding[padIdx];
-        }
-
-        p += QoiCodec.Padding.Length;
-
-        return bytes[..p];
+        return p;
     }
 
+
+    /// <summary>
+    /// Compress RGB data
+    /// </summary>
+    /// <param name="bytes">bytes to compress</param>
+    /// <param name="r">current Red value</param>
+    /// <param name="prevR">previous Red value</param>
+    /// <param name="g">current Green value</param>
+    /// <param name="prevG">previous Green value</param>
+    /// <param name="b">current Blue value</param>
+    /// <param name="prevB">previous Blue value</param>
+    /// <param name="p">current position in the <paramref name="bytes"/></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void CompressRGB(Span<byte> bytes, byte r, byte prevR, byte g, byte prevG, byte b, byte prevB, ref int p)
+    {
+        int vr = r - prevR;
+        int vg = g - prevG;
+        int vb = b - prevB;
+
+        if (vr is > -3 and < 2 &&
+            vg is > -3 and < 2 &&
+            vb is > -3 and < 2)
+        {
+            bytes[p++] = (byte)(QoiCodec.Diff | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2));
+        }
+        else
+        {
+            int vgr = vr - vg;
+            int vgb = vb - vg;
+
+            if (vgr is > -9 and < 8 &&
+                vg is > -33 and < 32 &&
+                vgb is > -9 and < 8)
+            {
+                bytes[p++] = (byte)(QoiCodec.Luma | (vg + 32));
+                bytes[p++] = (byte)((vgr + 8) << 4 | (vgb + 8));
+            }
+            else
+            {
+                bytes[p++] = QoiCodec.Rgb;
+                bytes[p++] = r;
+                bytes[p++] = g;
+                bytes[p++] = b;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool RgbaEquals(byte r1, byte g1, byte b1, byte a1, byte r2, byte g2, byte b2, byte a2) =>
         r1 == r2 &&
         g1 == g2 &&
         b1 == b2 &&
         a1 == a2;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool RgbEquals(byte r1, byte g1, byte b1, byte r2, byte g2, byte b2) =>
+        r1 == r2 &&
+        g1 == g2 &&
+        b1 == b2;
 }


### PR DESCRIPTION
Hey, 
saw there was a .Net port of QOI and got curious about the new performance things that .net standard has. Here is what I came up with:

Encode:
|          Method | CurrentPath |         Mean |     Error |    StdDev | Ratio |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|---------------- |------------ |-------------:|----------:|----------:|------:|--------:|--------:|--------:|----------:|
|  OriginalEncode |   Large.jpg | 201,046.6 us | 722.04 us | 675.39 us |  1.00 |       - |       - |       - | 74,109 KB |
| OptimisedEncode |   Large.jpg | 139,210.1 us | 332.80 us | 295.02 us |  0.69 |       - |       - |       - | 18,885 KB |
|                 |             |              |           |           |       |         |         |         |           |
|  OriginalEncode |  Medium.jpg |  11,649.1 us |  47.91 us |  42.47 us |  1.00 | 31.2500 | 31.2500 | 31.2500 |  4,385 KB |
| OptimisedEncode |  Medium.jpg |   7,930.6 us |  73.48 us |  65.14 us |  0.68 |       - |       - |       - |  1,749 KB |
|                 |             |              |           |           |       |         |         |         |           |
|  OriginalEncode |   Small.jpg |   1,054.2 us |   1.55 us |   1.29 us |  1.00 |  1.9531 |  1.9531 |  1.9531 |    422 KB |
| OptimisedEncode |   Small.jpg |     724.7 us |   3.00 us |   2.81 us |  0.69 |       - |       - |       - |    129 KB |

Decode:
|          Method | CurrentPath |         Mean |     Error |    StdDev | Ratio |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------- |------------ |-------------:|----------:|----------:|------:|---------:|---------:|---------:|----------:|
|  OriginalDecode |   Large.qoi | 127,637.5 us | 576.69 us | 539.43 us |  1.00 | 250.0000 | 250.0000 | 250.0000 | 55,285 KB |
| OptimisedDecode |   Large.qoi | 123,073.7 us | 222.35 us | 197.11 us |  0.96 | 250.0000 | 250.0000 | 250.0000 | 55,284 KB |
|                 |             |              |           |           |       |          |          |          |           |
|  OriginalDecode |  Medium.qoi |   6,381.4 us |  26.74 us |  22.33 us |  1.00 |  46.8750 |  46.8750 |  46.8750 |  2,637 KB |
| OptimisedDecode |  Medium.qoi |   5,763.2 us |  41.81 us |  39.11 us |  0.90 |  70.3125 |  70.3125 |  70.3125 |  2,637 KB |
|                 |             |              |           |           |       |          |          |          |           |
|  OriginalDecode |   Small.qoi |     636.7 us |   1.35 us |   1.19 us |  1.00 |   5.8594 |   5.8594 |   5.8594 |    293 KB |
| OptimisedDecode |   Small.qoi |     630.1 us |   9.91 us |   9.27 us |  0.99 |   7.8125 |   7.8125 |   7.8125 |    293 KB |

I think that potential users would quite like these changes as it's a nice speedup overall

Main changes
- Minimize GC by using `ArrayPool` to use a temporary array when encoding/decoding so that nothing needs to be allocated and thrown away.
- Use `Span` for readonly array access and it has a lower overhead (funnily enough not all places where there was an array had a benefit from Span)
- Some aggressive in-lining means that small methods don't add a new stack frame and improves performance at the expense of assembly size (but the amount of usages in this case don't make a huge difference to size)

Minor changes
- split the rgba and rgb code so that there are no redundant checks inside the loop which reduces branching (and cuts down on some CPU work). This does give about a 5-7% improvement but it does massively increase the size of the code and makes some duplicate code so I can understand not wanting this part of the change.