### PR TITLE
Improve performance without breaking API

### DIFF
--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -49,5 +49,5 @@ public static class QoiCodec
         => IsValidMagic(new ReadOnlySpan<byte>(magic, 0, 4));
 
     internal static bool IsValidMagic(ReadOnlySpan<byte> magic)
-        => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
+        => BinaryPrimitives.ReadInt32BigEndian(magic) == Magic;
 }

--- a/src/QoiSharp/Codec/QoiCodec.cs
+++ b/src/QoiSharp/Codec/QoiCodec.cs
@@ -1,4 +1,6 @@
-﻿namespace QoiSharp.Codec;
+﻿using System.Buffers.Binary;
+
+namespace QoiSharp.Codec;
 
 /// <summary>
 /// QOI Codec.
@@ -13,6 +15,9 @@ public static class QoiCodec
     public const byte Rgba = 0xFF;
     public const byte Mask2 = 0xC0;
 
+    // FIXME: 'MaxPixels' should be 'static readonly' (not const). At the moment
+    // it's mutable so users can reset this to arbitrary values.
+
     /// <summary>
     /// 2GB is the max file size that this implementation can safely handle. We guard
     /// against anything larger than that, assuming the worst case with 5 bytes per 
@@ -20,20 +25,29 @@ public static class QoiCodec
     /// enough for anybody.
     /// </summary>
     public static int MaxPixels = 400_000_000;
-    
+
+    internal static readonly int MaxPixelsReadOnly= 400_000_000;
+
     public const int HashTableSize = 64; 
     
     public const byte HeaderSize = 14;
     public const string MagicString = "qoif";
-    
-    public static readonly int Magic = CalculateMagic(MagicString.AsSpan());
-    public static readonly byte[] Padding = {0, 0, 0, 0, 0, 0, 0, 1};
 
+    public static readonly int Magic = 'q' << 24 | 'o' << 16 | 'i' << 8 | 'f';
+
+    // FIXME: This public API should be removed. This is an implementation detail.
+    [Obsolete("This field should not be used. It will be removed in v2.0")]
+    public static readonly byte[] Padding = new byte[] {0, 0, 0, 0, 0, 0, 0, 1};
+    internal static readonly ReadOnlyMemory<byte> ReadOnlyPadding = new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 };
+
+    // FIXME: This public API should be removed. This is an implementation detail.
+    [Obsolete("This method should not be used. It will be removed in v2.0")]
     public static int CalculateHashTableIndex(int r, int g, int b, int a) =>
         ((r & 0xFF) * 3 + (g & 0xFF) * 5 + (b & 0xFF) * 7 + (a & 0xFF) * 11) % HashTableSize * 4;
 
-    public static bool IsValidMagic(byte[] magic) => CalculateMagic(magic) == Magic;
-    
-    private static int CalculateMagic(ReadOnlySpan<char> chars) => chars[0] << 24 | chars[1] << 16 | chars[2] << 8 | chars[3];
-    private static int CalculateMagic(ReadOnlySpan<byte> data) => data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
+    public static bool IsValidMagic(byte[] magic)
+        => IsValidMagic(new ReadOnlySpan<byte>(magic, 0, 4));
+
+    internal static bool IsValidMagic(ReadOnlySpan<byte> magic)
+        => BinaryPrimitives.ReadInt32BigEndian (magic) == Magic;
 }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -1,8 +1,6 @@
 ﻿using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
-using System.Runtime.InteropServices;
-
 namespace QoiSharp;
 
 /// <summary>
@@ -86,7 +84,7 @@ public static class QoiDecoder
             else if ((b1 & QoiCodec.Mask2) == QoiCodec.Index)
             {
                 int indexPos = (b1 & ~QoiCodec.Mask2);
-                var value = index[indexPos];
+                uint value = index[indexPos];
                 r = (byte)(value >> 24);
                 g = (byte)(value >> 16);
                 b = (byte)(value >> 8);

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -1,12 +1,14 @@
 ﻿using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
+using System.Runtime.InteropServices;
+
 namespace QoiSharp;
 
 /// <summary>
 /// QOI decoder.
 /// </summary>
-public static class QoiDecoder 
+public static class QoiDecoder
 {
     /// <summary>
     /// Decodes QOI data into raw pixel data.
@@ -16,109 +18,104 @@ public static class QoiDecoder
     /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
     public static QoiImage Decode(byte[] data)
     {
-        if (data.Length < QoiCodec.HeaderSize + QoiCodec.Padding.Length)
+        if (data.Length < QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length)
         {
             throw new QoiDecodingException("File too short");
         }
-        
-        if (!QoiCodec.IsValidMagic(data[..4]))
+
+        if (!QoiCodec.IsValidMagic(data.AsSpan(0, 4)))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
         }
 
         int width = data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7];
         int height = data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11];
-        byte channels = data[12]; 
+        byte channels = data[12];
         var colorSpace = (ColorSpace)data[13];
 
         if (width == 0)
         {
             throw new QoiDecodingException($"Invalid width: {width}");
         }
-        if (height == 0 || height >= QoiCodec.MaxPixels / width)
+        if (height == 0 || height >= QoiCodec.MaxPixelsReadOnly / width)
         {
-            throw new QoiDecodingException($"Invalid height: {height}. Maximum for this image is {QoiCodec.MaxPixels / width - 1}");
+            throw new QoiDecodingException($"Invalid height: {height}. Maximum for this image is {QoiCodec.MaxPixelsReadOnly / width - 1}");
         }
         if (channels is not 3 and not 4)
         {
             throw new QoiDecodingException($"Invalid number of channels: {channels}");
         }
-        
-        byte[] index = new byte[QoiCodec.HashTableSize * 4];
-        if (channels == 3) // TODO: delete
-        {
-            for (int indexPos = 3; indexPos < index.Length; indexPos += 4)
-            {
-                index[indexPos] = 255;
-            }
-        }
+
+        Span<uint> index = stackalloc uint[QoiCodec.HashTableSize];
+        index.Fill(255);
 
         byte[] pixels = new byte[width * height * channels];
-        
-        byte r = 0;
-        byte g = 0;
-        byte b = 0;
-        byte a = 255;
-        
-        int run = 0;
+
+        byte r = 0, g = 0, b = 0, a = 255;
+
         int p = QoiCodec.HeaderSize;
 
         for (int pxPos = 0; pxPos < pixels.Length; pxPos += channels)
         {
-            if (run > 0)
-            {
-                run--;
-            }
-            else
-            {
-                byte b1 = data[p++];
+            byte b1 = data[p++];
 
-                if (b1 == QoiCodec.Rgb)
-                {
-                    r = data[p++];
-                    g = data[p++];
-                    b = data[p++];
-                }
-                else if (b1 == QoiCodec.Rgba)
-                {
-                    r = data[p++];
-                    g = data[p++];
-                    b = data[p++];
-                    a = data[p++];
-                }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Index)
-                {
-                    int indexPos = (b1 & ~QoiCodec.Mask2) * 4;
-                    r = index[indexPos];
-                    g = index[indexPos + 1];
-                    b = index[indexPos + 2];
-                    a = index[indexPos + 3];
-                }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Diff)
-                {
-                    r += (byte)(((b1 >> 4) & 0x03) - 2);
-                    g += (byte)(((b1 >> 2) & 0x03) - 2);
-                    b += (byte)((b1 & 0x03) - 2);
-                }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Luma) 
-                {
-                    int b2 = data[p++];
-                    int vg = (b1 & 0x3F) - 32;
-                    r += (byte)(vg - 8 + ((b2 >> 4) & 0x0F));
-                    g += (byte)vg;
-                    b += (byte)(vg - 8 + (b2 & 0x0F));
-                }
-                else if ((b1 & QoiCodec.Mask2) == QoiCodec.Run) 
-                {
-                    run = b1 & 0x3F;
-                }
-                
-                int indexPos2 = QoiCodec.CalculateHashTableIndex(r, g, b, a);
-                index[indexPos2] = r;
-                index[indexPos2 + 1] = g;
-                index[indexPos2 + 2] = b;
-                index[indexPos2 + 3] = a;
+            if (b1 == QoiCodec.Rgb)
+            {
+                r = data[p];
+                g = data[p + 1];
+                b = data[p + 2];
+                p += 3;
             }
+            else if (b1 == QoiCodec.Rgba)
+            {
+                r = data[p];
+                g = data[p + 1];
+                b = data[p + 2];
+                a = data[p + 3];
+                p += 4;
+            }
+            else if ((b1 & QoiCodec.Mask2) == QoiCodec.Index)
+            {
+                int indexPos = (b1 & ~QoiCodec.Mask2);
+                var value = index[indexPos];
+                r = (byte)(value >> 24);
+                g = (byte)(value >> 16);
+                b = (byte)(value >> 8);
+                a = (byte)(value >> 0);
+            }
+            else if ((b1 & QoiCodec.Mask2) == QoiCodec.Diff)
+            {
+                r += (byte)(((b1 >> 4) & 0x03) - 2);
+                g += (byte)(((b1 >> 2) & 0x03) - 2);
+                b += (byte)((b1 & 0x03) - 2);
+            }
+            else if ((b1 & QoiCodec.Mask2) == QoiCodec.Luma)
+            {
+                int b2 = data[p++];
+                int vg = (b1 & 0x3F) - 32;
+                r += (byte)(vg - 8 + ((b2 >> 4) & 0x0F));
+                g += (byte)vg;
+                b += (byte)(vg - 8 + (b2 & 0x0F));
+            }
+            else if ((b1 & QoiCodec.Mask2) == QoiCodec.Run && b1 != QoiCodec.Run) // Only execute this block if there's at least 1 additional run.
+            {
+                int run = b1 & 0x3F;
+                int end = pxPos + run * channels;
+                while (pxPos < end)
+                {
+                    pixels[pxPos] = r;
+                    pixels[pxPos + 1] = g;
+                    pixels[pxPos + 2] = b;
+                    if (channels == 4)
+                    {
+                        pixels[pxPos + 3] = a;
+                    }
+                    pxPos += channels;
+                }
+            }
+
+            int indexPos2 = (r * 3 + g * 5 + b * 7 + a * 11) % QoiCodec.HashTableSize;
+            index[indexPos2] = ((uint)r << 24) | ((uint)g << 16) | ((uint)b << 8) | (uint)a;
 
             pixels[pxPos] = r;
             pixels[pxPos + 1] = g;
@@ -128,15 +125,9 @@ public static class QoiDecoder
                 pixels[pxPos + 3] = a;
             }
         }
-        
-        int pixelsEnd = data.Length - QoiCodec.Padding.Length;
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++) 
-        {
-            if (data[pixelsEnd + padIdx] != QoiCodec.Padding[padIdx]) 
-            {
-                throw new InvalidOperationException("Invalid padding");
-            }
-        }
+
+        if (!QoiCodec.ReadOnlyPadding.Span.SequenceEqual(data.AsSpan(p, QoiCodec.ReadOnlyPadding.Length)))
+            throw new InvalidOperationException("Invalid padding");
 
         return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);
     }

--- a/src/QoiSharp/QoiDecoder.cs
+++ b/src/QoiSharp/QoiDecoder.cs
@@ -17,13 +17,22 @@ public static class QoiDecoder
     /// <returns>Decoding result.</returns>
     /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
     public static QoiImage Decode(byte[] data)
+        => Decode(data.AsSpan());
+
+    /// <summary>
+    /// Decodes QOI data into raw pixel data.
+    /// </summary>
+    /// <param name="data">QOI data</param>
+    /// <returns>Decoding result.</returns>
+    /// <exception cref="QoiDecodingException">Thrown when data is invalid.</exception>
+    public static QoiImage Decode(ReadOnlySpan<byte> data)
     {
         if (data.Length < QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length)
         {
             throw new QoiDecodingException("File too short");
         }
 
-        if (!QoiCodec.IsValidMagic(data.AsSpan(0, 4)))
+        if (!QoiCodec.IsValidMagic(data.Slice(0, 4)))
         {
             throw new QoiDecodingException("Invalid file magic"); // TODO: add magic value
         }
@@ -126,7 +135,7 @@ public static class QoiDecoder
             }
         }
 
-        if (!QoiCodec.ReadOnlyPadding.Span.SequenceEqual(data.AsSpan(p, QoiCodec.ReadOnlyPadding.Length)))
+        if (!QoiCodec.ReadOnlyPadding.Span.SequenceEqual(data.Slice(p, QoiCodec.ReadOnlyPadding.Length)))
             throw new InvalidOperationException("Invalid padding");
 
         return new QoiImage(pixels, width, height, (Channels)channels, colorSpace);

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -19,7 +19,7 @@ public static class QoiEncoder
     /// <exception cref="QoiEncodingException">Thrown when image information is invalid.</exception>
     public static byte[] Encode(QoiImage image)
     {
-        var bytes = new byte[QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length + (image.Width * image.Height * (byte)image.Channels)];
+        var bytes = new byte[QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length + (image.Width * image.Height * (int)image.Channels)];
         return bytes[..Encode(image, bytes)];
     }
 
@@ -84,6 +84,7 @@ public static class QoiEncoder
                     buffer[p++] = (byte)(QoiCodec.Run | (run - 1));
                     run = 0;
                 }
+                continue;
             }
             else
             {

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -65,6 +65,7 @@ public static class QoiEncoder
 
         ref uint prevAsInt = ref MemoryMarshal.Cast<byte, uint>(prev)[0];
         ref uint rgbaAsInt = ref MemoryMarshal.Cast<byte, uint>(rgba)[0];
+        index.Fill(rgbaAsInt);
 
         int run = 0;
         int counter = 0;

--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -1,6 +1,9 @@
 ﻿using QoiSharp.Codec;
 using QoiSharp.Exceptions;
 
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
 namespace QoiSharp;
 
 /// <summary>
@@ -9,85 +12,75 @@ namespace QoiSharp;
 public static class QoiEncoder
 {
     /// <summary>
-    /// Encodes raw pixel data into QOI.
+    /// Encodes raw pixel data into QOI format.
     /// </summary>
     /// <param name="image">QOI image.</param>
     /// <returns>Encoded image.</returns>
     /// <exception cref="QoiEncodingException">Thrown when image information is invalid.</exception>
     public static byte[] Encode(QoiImage image)
     {
+        var bytes = new byte[QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length + (image.Width * image.Height * (byte)image.Channels)];
+        return bytes[..Encode(image, bytes)];
+    }
+
+    /// <summary>
+    /// Encodes raw pixel data into QOI format.
+    /// </summary>
+    /// <param name="image">The image to encode.</param>
+    /// <param name="buffer">The buffer to receive the encoded bytes</param>
+    /// <exception cref="QoiEncodingException">Thrown when image information is invalid.</exception>
+    /// <returns>The number of bytes written to the span</returns>
+    public static int Encode(QoiImage image, Span<byte> buffer)
+    {
         if (image.Width == 0)
         {
             throw new QoiEncodingException($"Invalid width: {image.Width}");
         }
 
-        if (image.Height == 0 || image.Height >= QoiCodec.MaxPixels / image.Width)
+        if (image.Height == 0 || image.Height >= QoiCodec.MaxPixelsReadOnly / image.Width)
         {
-            throw new QoiEncodingException($"Invalid height: {image.Height}. Maximum for this image is {QoiCodec.MaxPixels / image.Width - 1}");
+            throw new QoiEncodingException($"Invalid height: {image.Height}. Maximum for this image is {QoiCodec.MaxPixelsReadOnly / image.Width - 1}");
         }
 
         int width = image.Width;
         int height = image.Height;
-        byte channels = (byte)image.Channels;
+        int channels = (int)image.Channels;
         byte colorSpace = (byte)image.ColorSpace;
-        byte[] pixels = image.Data;
 
-        byte[] bytes = new byte[QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * channels)];
+        if (buffer.Length < QoiCodec.HeaderSize + QoiCodec.ReadOnlyPadding.Length + (width * height * channels))
+            return -1;
 
-        bytes[0] = (byte)(QoiCodec.Magic >> 24);
-        bytes[1] = (byte)(QoiCodec.Magic >> 16);
-        bytes[2] = (byte)(QoiCodec.Magic >> 8);
-        bytes[3] = (byte)QoiCodec.Magic;
+        BinaryPrimitives.WriteInt32BigEndian(buffer, QoiCodec.Magic);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(4), width);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(8), height);
 
-        bytes[4] = (byte)(width >> 24);
-        bytes[5] = (byte)(width >> 16);
-        bytes[6] = (byte)(width >> 8);
-        bytes[7] = (byte)width;
+        buffer[12] = (byte)channels;
+        buffer[13] = colorSpace;
 
-        bytes[8] = (byte)(height >> 24);
-        bytes[9] = (byte)(height >> 16);
-        bytes[10] = (byte)(height >> 8);
-        bytes[11] = (byte)height;
+        Span<uint> index = stackalloc uint[QoiCodec.HashTableSize];
 
-        bytes[12] = channels;
-        bytes[13] = colorSpace;
+        Span<byte> prev = stackalloc byte[4] { 0, 0, 0, 255 };
+        Span<byte> rgba = stackalloc byte[4] { 0, 0, 0, 255 };
+        Span<byte> rgb = rgba.Slice(0, 3);
 
-        byte[] index = new byte[QoiCodec.HashTableSize * 4];
-
-        byte prevR = 0;
-        byte prevG = 0;
-        byte prevB = 0;
-        byte prevA = 255;
-
-        byte r = 0;
-        byte g = 0;
-        byte b = 0;
-        byte a = 255;
+        ref uint prevAsInt = ref MemoryMarshal.Cast<byte, uint>(prev)[0];
+        ref uint rgbaAsInt = ref MemoryMarshal.Cast<byte, uint>(rgba)[0];
 
         int run = 0;
-        int p = QoiCodec.HeaderSize;
-        bool hasAlpha = channels == 4;
-
-        int pixelsLength = width * height * channels;
-        int pixelsEnd = pixelsLength - channels;
         int counter = 0;
-
-        for (int pxPos = 0; pxPos < pixelsLength; pxPos += channels)
+        int p = QoiCodec.HeaderSize;
+        var pixels = image.Data.AsSpan(0, width * height * channels);
+        while (pixels.Length > 0)
         {
-            r = pixels[pxPos];
-            g = pixels[pxPos + 1];
-            b = pixels[pxPos + 2];
-            if (hasAlpha)
-            {
-                a = pixels[pxPos + 3];
-            }
+            pixels.Slice(0, channels).CopyTo(rgba);
+            pixels = pixels.Slice(channels);
 
-            if (RgbaEquals(prevR, prevG, prevB, prevA, r, g, b, a))
+            if (prevAsInt == rgbaAsInt)
             {
                 run++;
-                if (run == 62 || pxPos == pixelsEnd)
+                if (run == 62 || pixels.Length == 0)
                 {
-                    bytes[p++] = (byte)(QoiCodec.Run | (run - 1));
+                    buffer[p++] = (byte)(QoiCodec.Run | (run - 1));
                     run = 0;
                 }
             }
@@ -95,28 +88,24 @@ public static class QoiEncoder
             {
                 if (run > 0)
                 {
-                    bytes[p++] = (byte)(QoiCodec.Run | (run - 1));
+                    buffer[p++] = (byte)(QoiCodec.Run | (run - 1));
                     run = 0;
                 }
 
-                int indexPos = QoiCodec.CalculateHashTableIndex(r, g, b, a);
-
-                if (RgbaEquals(r, g, b, a, index[indexPos], index[indexPos + 1], index[indexPos + 2], index[indexPos + 3]))
+                int indexPos = (rgba[0] * 3 + rgba[1] * 5 + rgba[2] * 7 + rgba[3] * 11) % QoiCodec.HashTableSize;
+                if (rgbaAsInt == index[indexPos])
                 {
-                    bytes[p++] = (byte)(QoiCodec.Index | (indexPos / 4));
+                    buffer[p++] = (byte)(QoiCodec.Index | (indexPos));
                 }
                 else
                 {
-                    index[indexPos] = r;
-                    index[indexPos + 1] = g;
-                    index[indexPos + 2] = b;
-                    index[indexPos + 3] = a;
+                    index[indexPos] = rgbaAsInt;
 
-                    if (a == prevA)
+                    if (rgba[3] == prev[3])
                     {
-                        int vr = r - prevR;
-                        int vg = g - prevG;
-                        int vb = b - prevB;
+                        int vr = rgba[0] - prev[0];
+                        int vg = rgba[1] - prev[1];
+                        int vb = rgba[2] - prev[2];
 
                         int vgr = vr - vg;
                         int vgb = vb - vg;
@@ -126,54 +115,37 @@ public static class QoiEncoder
                             vb is > -3 and < 2)
                         {
                             counter++;
-                            bytes[p++] = (byte)(QoiCodec.Diff | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2));
+                            buffer[p++] = (byte)(QoiCodec.Diff | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2));
                         }
                         else if (vgr is > -9 and < 8 &&
                                  vg is > -33 and < 32 &&
                                  vgb is > -9 and < 8
                                 )
                         {
-                            bytes[p++] = (byte)(QoiCodec.Luma | (vg + 32));
-                            bytes[p++] = (byte)((vgr + 8) << 4 | (vgb + 8));
+                            buffer[p++] = (byte)(QoiCodec.Luma | (vg + 32));
+                            buffer[p++] = (byte)((vgr + 8) << 4 | (vgb + 8));
                         }
                         else
                         {
-                            bytes[p++] = QoiCodec.Rgb;
-                            bytes[p++] = r;
-                            bytes[p++] = g;
-                            bytes[p++] = b;
+                            buffer[p++] = QoiCodec.Rgb;
+                            rgb.CopyTo(buffer.Slice(p));
+                            p += 3;
                         }
                     }
                     else
                     {
-                        bytes[p++] = QoiCodec.Rgba;
-                        bytes[p++] = r;
-                        bytes[p++] = g;
-                        bytes[p++] = b;
-                        bytes[p++] = a;
+                        buffer[p++] = QoiCodec.Rgba;
+                        rgba.CopyTo(buffer.Slice(p));
+                        p += 4;
                     }
                 }
             }
-
-            prevR = r;
-            prevG = g;
-            prevB = b;
-            prevA = a;
+            prevAsInt = rgbaAsInt;
         }
 
-        for (int padIdx = 0; padIdx < QoiCodec.Padding.Length; padIdx++)
-        {
-            bytes[p + padIdx] = QoiCodec.Padding[padIdx];
-        }
+        QoiCodec.ReadOnlyPadding.Span.CopyTo(buffer.Slice(p));
+        p += QoiCodec.ReadOnlyPadding.Length;
 
-        p += QoiCodec.Padding.Length;
-
-        return bytes[..p];
+        return p;
     }
-
-    private static bool RgbaEquals(byte r1, byte g1, byte b1, byte a1, byte r2, byte g2, byte b2, byte a2) =>
-        r1 == r2 &&
-        g1 == g2 &&
-        b1 == b2 &&
-        a1 == a2;
 }


### PR DESCRIPTION
The original PR was pushed a bit too late and
wasn't reviewed before 1.0 was released. As such,
the changes can't be included now without breaking
API.

Redo some of the changes to gain most of the benefits
without the API breakage.

1. Nothing in the library uses the public mutable
state defined in QoiCodec.These properties/fields
have been replaced with immutable/readonly properties
instead.

2. QoiEncoder has been optimised a bit to leverage
the performance gains from BinaryPrimitives and Span<T>.
Also, a Span<T> based overload was added so that images
could be encoded into a reusable buffer.

3. QoiDecoder has a new overload which receives a
Span<T>, allowing images to be decoded from anything
which can create a Span<byte>, and also allows for
multiple images to be decoded from the same underlying
array.