### PR TITLE
fixed the main buffer's size

### DIFF
--- a/src/QoiSharp/QoiEncoder.cs
+++ b/src/QoiSharp/QoiEncoder.cs
@@ -32,7 +32,7 @@ public static class QoiEncoder
         byte colorSpace = (byte)image.ColorSpace;
         byte[] pixels = image.Data;
 
-        byte[] bytes = new byte[QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * channels)];
+        byte[] bytes = new byte[QoiCodec.HeaderSize + QoiCodec.Padding.Length + (width * height * (channels + 1))];
 
         bytes[0] = (byte)(QoiCodec.Magic >> 24);
         bytes[1] = (byte)(QoiCodec.Magic >> 16);


### PR DESCRIPTION
Encoding throws System.IndexOutOfRangeException without the fix.

Example:
- width: 1
- height: 1
- channels: 4
- space: srgb or linear
- pixel: rgba (5, 10, 20, 0)  or rgba (100, 100, 100, 1)

see also https://github.com/phoboslab/qoi/blob/805953b1c7310a0f78839938786340e9db33c8ee/qoi.h#L394 